### PR TITLE
Distinguish "open source" from GitHub

### DIFF
--- a/source/rules.md
+++ b/source/rules.md
@@ -11,7 +11,8 @@ Each static site generator is a markdown file in the `source/projects` directory
 We'll only accept pull requests adding new static site generators if they follow the following rules:
 
 *   **Static Site Generation:** No "flat-file CMSs" or similar tools. The program must be able to output a static website that can be hosted in places like BitBalloon, S3 or Github Pages.
-*   **Open Source:** The generator must have a public repository on Github that we can link to and pull in stats from.
+*   **Open Source:** The generator must be released under an open source license.
+*   **Accessible on GitHub:** The generator must have a public repository on Github that we can link to and pull in stats from.
 *   **Stick to the format:** Fill out all the same fields as the other static site generators in `source/projects`.
 
 Many static site generators support different template engines. Don't list them all in the template field, just the one(s) used by default. Feel free to go into more details in the body text.


### PR DESCRIPTION
It's a pedantic point, but being open source does not mean that your project is on GitHub, and being on GitHub does not mean that your project is open source.  The rules page shouldn't treat them as the same thing.
