### PR TITLE
add drupan

### DIFF
--- a/source/projects/drupan.md
+++ b/source/projects/drupan.md
@@ -1,0 +1,26 @@
+---
+title: drupan
+repo: fallenhitokiri/drupan
+homepage: https://github.com/fallenhitokiri/drupan
+language: Python
+license: BSD
+templates: Jinja2
+description: trying to hit the sweet spot between simplicity and being feature rich enough for every use case.
+---
+
+Drupan is a static site generator which initially focused on blogs and is now evolving into a universal tool working for blogs, single page applications and conventional websites alike.
+
+The goal is to give developers and designers one tool they can rely on, that gets the job done and does not require hours of customization and plugins to generate a site.
+
+### Notable Features
+* Jinja2 with custom filters to allow easily accessing, iterating and filtering all your different entities.
+* Sane plugin architecture allowing you to easily add missing functionality.
+* No enforced structure of meta data and content.
+* Active developed.
+
+### Upcoming Features
+There is a 2.0 release in alpha testing which will bring the following features
+
+* S3 and CloudFront support
+* Better Jinja2 filters
+* Faster site generation


### PR DESCRIPTION
Drupan is a static site generator which initially focused on blogs and is now evolving into a universal tool working for blogs, single page applications and conventional websites alike.
