### PR TITLE
Fix Zodiac Language

### DIFF
--- a/source/projects/zodiac.md
+++ b/source/projects/zodiac.md
@@ -2,9 +2,9 @@
 title: Zodiac
 repo: nuex/zodiac
 homepage: http://github.com/nuex/zodiac
-language: awk, sh
+language: Awk
 license: MIT
-templates: mustache-like
+templates: Mustache-like
 description: A static site generator powered by awk and sh.
 ---
 


### PR DESCRIPTION
Zodiac wasnt coming up when searching for "awk, sh" so I changed it to the primary language "Awk". It shows up now.

Also capitalized "Mustache-like".
