### PR TITLE
Specified snippet language to fix highlighting.

### DIFF
--- a/source/projects/tclssg.md
+++ b/source/projects/tclssg.md
@@ -22,18 +22,20 @@ Tclssg is a static site generator written in Tcl that uses Markdown for content 
 
 ### Page example
 
-    {
-        pageTitle {Test page}
-        blogPost 1
-        tags {test {a long tag with spaces}}
-        date 2014-01-02
-        hideDate 1
-    }
-    **Lorem ipsum** reprehenderit _ullamco deserunt sit eiusmod_ ut minim in id
-    voluptate proident enim eu aliqua sit.
+```markdown
+{
+    pageTitle {Test page}
+    blogPost 1
+    tags {test {a long tag with spaces}}
+    date 2014-01-02
+    hideDate 1
+}
+**Lorem ipsum** reprehenderit _ullamco deserunt sit eiusmod_ ut minim in id
+voluptate proident enim eu aliqua sit.
 
-    <!-- more -->
+<!-- more -->
 
-    Mollit ex cillum pariatur anim [exemplum](http://example.com) tempor
-    exercitation sed eu Excepteur dolore deserunt cupidatat aliquip irure in
-    fugiat eu laborum est.
+Mollit ex cillum pariatur anim [exemplum](http://example.com) tempor
+exercitation sed eu Excepteur dolore deserunt cupidatat aliquip irure in
+fugiat eu laborum est.
+```


### PR DESCRIPTION
Markup snippet was mistakenly detected as JSON and highlighted with red as containing errors.
