### PR TITLE
added minerl.md

### DIFF
--- a/source/projects/minerl.md
+++ b/source/projects/minerl.md
@@ -1,0 +1,15 @@
+---
+title: Minerl
+repo: neevek/minerl
+homepage: https://github.com/neevek/minerl
+language: Perl
+license: Artistic License (2.0)
+templates: HTML::Template
+description: Minerl is a blog-aware static site generator written in Perl, it supports tagging, automatic archiving, post, page and layout inheritance.
+---
+
+Minerl is a blog-aware static site generator written in Perl.
+
+### Minerl
+
+Visit [https://github.com/neevek/minerl](https://github.com/neevek/minerl) for more details.


### PR DESCRIPTION
Minerl is a blog-aware static site generator written in Perl, it supports tagging, automatic archiving, post, page and layout inheritance.
