### PR TITLE
Update Hugo with new homepage url

### DIFF
--- a/source/projects/hugo.md
+++ b/source/projects/hugo.md
@@ -1,7 +1,7 @@
 ---
 title: Hugo
 repo: spf13/hugo
-homepage: http://hugo.spf13.com/
+homepage: http://gohugo.io/
 language: Go
 license: SimPL-2.0
 templates: Go Templates


### PR DESCRIPTION
http://hugo.spf13.com/ (old url) now redirects to http://gohugo.io/ (new url)
