### PR TITLE
Fix broken link

### DIFF
--- a/source/projects/metalsmith.md
+++ b/source/projects/metalsmith.md
@@ -41,7 +41,7 @@ Each plugin is invoked with the contents of the source directory, and each file 
 }
 ```
 
-...which any of the plugins can then manipulate however they want. And writing the plugins is incredibly simple, just take a look at the [example drafts plugin](examples/drafts-plugin/index.js).
+...which any of the plugins can then manipulate however they want. And writing the plugins is incredibly simple, just take a look at the [example drafts plugin](https://github.com/segmentio/metalsmith-drafts/blob/master/lib/index.js).
 
 Of course they can get a lot more complicated too. That's what makes Metalsmith powerful; the plugins can do anything you want!
 


### PR DESCRIPTION
Replace the broken internal link to the example plugin (which was copy-pasted from the project's README) with a full working URL.