### PR TITLE
Remove "only" from the dropdown

### DIFF
--- a/source/includes/_navbar.erb
+++ b/source/includes/_navbar.erb
@@ -5,7 +5,7 @@
         <select name="filter" class="dropdown-select">
           <option value="" selected>All languages</option>
           <% languages.each do |language| %>
-            <option value=".lang-<%= language.downcase.gsub(/\s/, '-') %>">Only <%= language %></option>
+            <option value=".lang-<%= language.downcase.gsub(/\s/, '-') %>"><%= language %></option>
           <% end %>
         </select>
       </div>


### PR DESCRIPTION
Unless my rationale is wrong, the word _only_ makes it __harder__ to search for a language. Drop-downs are single-selection anyway, so it's obvious what the element stands for. What do you think?