### PR TITLE
Fix pelican license

### DIFF
--- a/source/projects/pelican.md
+++ b/source/projects/pelican.md
@@ -3,7 +3,7 @@ title: Pelican
 repo: getpelican/pelican
 homepage: http://blog.getpelican.com/
 language: Python
-license: GPL
+license: AGPL
 templates: Jinja2
 description: A static site generator, imports from Wordpress, multi-lang publishing.
 ---


### PR DESCRIPTION
Pelican's [license](https://github.com/getpelican/pelican/blob/master/LICENSE) is Affero GPL.