### PR TITLE
Adding spotify/lingon to projects

### DIFF
--- a/source/projects/lingon.md
+++ b/source/projects/lingon.md
@@ -1,0 +1,13 @@
+---
+title: Lingon
+repo: spotify/lingon
+homepage: http://www.lingon.io/
+language: JavaScript
+license: Apache License Version 2
+templates: ejs
+description: Lingon is a performant single-page application dev tool that focuses on developer happiness.
+---
+
+Lingon is a build tool that favors convention over configuration. By employing a similar file structure across your projects you can minimize the amount of build configuration you need to write and maintain. We've borrowed this idea from middleman and Sprockets. If you already know these tools you'll feel right at home with Lingon.
+
+Lingon is compatible with gulp.js plugins. It allows you to enjoy the productive workflows from Middleman while leveraging an existing community of great gulp.js plugins.


### PR DESCRIPTION
Lingon started as a JavaScript port of Middleman. It has evolved to static site generator with extra focus on single-page JavaScript apps.