### PR TITLE
Hugo v0.15, released today, is now under Apache-2.0 License

### DIFF
--- a/source/projects/hugo.md
+++ b/source/projects/hugo.md
@@ -3,7 +3,7 @@ title: Hugo
 repo: spf13/hugo
 homepage: http://gohugo.io/
 language: Go
-license: SimPL-2.0
+license: Apache-2.0
 templates: Go Templates
 description: A Fast and Flexible Static Site Generator.
 ---


### PR DESCRIPTION
It will take some time to get all contributors to Hugo to sign the CLA (Contributor License Agreement),
but it is progressing nicely, especially now signing the CLA is part of the workflow—a prerequisite for new changes to be accepted.

Many thanks!
Anthony