### PR TITLE
Add Lerret

### DIFF
--- a/source/projects/lerret.md
+++ b/source/projects/lerret.md
@@ -1,0 +1,13 @@
+---
+title: Lerret
+repo: jgrh/lerret
+homepage: https://github.com/jgrh/lerret
+language: JavaScript
+license: APL 2.0
+templates: Jade
+description: A static site generator for image galleries.
+---
+
+Lerret is a simple static site generator for image oriented sites, powered by [Node.js](http://nodejs.org). Whilst usable out of the box, Lerret's behaviour can be easily customised and extended through its plugin framework.
+
+Lerret takes care of templating and image repurposing. Lerret doesn't come with any built in tools for generating stylesheets, minifying Javascript, or packaging and deploying your sites. Instead, it's recommended that you use your favourite tools directly to supplement what Lerret does well.


### PR DESCRIPTION
Add markdown file for Lerret.

Lerret is a simple static site generator for image oriented sites, powered by Node.js. Whilst usable out of the box, Lerret's behaviour can be easily customised and extended through its plugin framework.

Lerret takes care of templating and image repurposing. Lerret doesn't come with any built in tools for generating stylesheets, minifying Javascript, or packaging and deploying your sites. Instead, it's recommended that you use your favourite tools directly to supplement what Lerret does well.