### PR TITLE
add entry for iMatix GSL code generation tool

### DIFF
--- a/source/projects/gsl.md
+++ b/source/projects/gsl.md
@@ -1,0 +1,14 @@
+---
+title: GSL
+repo: imatix/gsl
+homepage: http://github.com/imatix/gsl
+language: C
+license: GPLv3+
+templates: XML
+description: GSL, a Universal Code Generator
+---
+
+GSL/4.1 is a code construction tool. It will generate code in all languages and
+for all purposes. In addition to code construction, GSL has been used to
+generate database schema definitions, user interfaces, reports, system
+administration tools and much more.


### PR DESCRIPTION
GSL can be used to generate static sites, with its templates and scripts. More examples are available here: https://github.com/imatix/gsl#toc3-287