### PR TITLE
Adding projects/apt-now.md

### DIFF
--- a/source/projects/apt-now.md
+++ b/source/projects/apt-now.md
@@ -3,7 +3,7 @@ title: apt-now
 repo: cmotc/apt-now
 homepage: http://cmotc.github.io/apt-now
 language: *sh
-license: MIT
+license: AGPL3
 templates: CSS
 description: Instant custom debian repositories
 ---

--- a/source/projects/apt-now.md
+++ b/source/projects/apt-now.md
@@ -1,0 +1,23 @@
+﻿---
+title: apt-now
+repo: cmotc/apt-now
+homepage: http://cmotc.github.io/apt-now
+language: *sh
+license: MIT
+templates: CSS
+description: Instant custom debian repositories
+---
+
+This tool is essentially a static site generator geared toward generating and
+formatting a specific type of content in a specific type of way, the content being
+GNU/Linux or Android/Linux binary packages, and the format being a signed
+repository accessible from the web or something like it(It can also, for instance,
+be used to statically host software repositories over i2p with no substantial
+modification.) It does this by taking advantage of the structural regularity of
+these types of resources and constructs the whole site on the client side,
+transmitting content to the server only after a valid repository has been built.
+This means that the server doesn't have to run any code at all to present the site
+to the end-user taking advantage of the resource over the web, doesn't need to
+support ssh or remote desktop, and doesn't even technically need to support ftp or
+git, as long as a way of transferring the repository to the remote storage service
+can be included in the program.

--- a/source/projects/apt-now.md
+++ b/source/projects/apt-now.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: apt-now
 repo: cmotc/apt-now
 homepage: http://cmotc.github.io/apt-now


### PR DESCRIPTION
So, I use Debian as the basis for the operating system on my computers, but as everyone knows, Debian favors well-tested, older packages and sometimes newer ones can be slow to arrive. When adding sid and pinning stable doesn't work, but you still need the packages you usually have to build from source, which means your package manager might not be aware of the files. When this became a problem for me I started building .debs of all my custom packages, then one thing led to another and... apt-now. What it is is a shell script which grabs information from Debian packages, generates informational pages about the packages, and an index for those pages, and spits out a signed apt repository on the other side. It can host itself, it can run on github pages, and I also make it a Tor Hidden Service and an i2p eepSite, just for fun. That's all pretty much supported, with one slight caveat for existing i2p eepSite operators(Where with will change your default eepSite docroot), but that's probably temporary. But that's it. Packages go in, repos come out.