### PR TITLE
Add Motyl

### DIFF
--- a/source/projects/motyl.md
+++ b/source/projects/motyl.md
@@ -1,0 +1,23 @@
+---
+title: Motyl
+repo: fcambus/motyl
+homepage: http://www.cambus.net/motyl/
+language: Lua
+license: BSD
+templates: Mustache
+description: Opinionated static site generator written in Lua.
+---
+
+Motyl is an opinionated static site generator written in Lua.
+
+It uses Mustache as templating system, and all content is written in Markdown.
+
+## Features
+
+- Small and easy to understand code
+- Minimal dependencies (only four Lua rocks)
+- Pages and posts written in Markdown
+- Templates are logic-less and use Mustache
+- Support for categories
+- Customizable URLs (constructed from filename)
+- Atom feed generator


### PR DESCRIPTION
Add Motyl, an opinionated static site generator written in Lua.