### PR TITLE
Update the "repo" field of octopress.md

### DIFF
--- a/source/projects/octopress.md
+++ b/source/projects/octopress.md
@@ -1,6 +1,6 @@
 ---
 title: Octopress
-repo: imathis/octopress
+repo: octopress/octopress
 homepage: http://octopress.org
 language: Ruby
 license: MIT


### PR DESCRIPTION
Octopress has been moved to a new repository, so the "repo" field needs to be updated in the `octopress.md` file.