### PR TITLE
Update repo for Hugo: new "gohugoio" organization

### DIFF
--- a/source/projects/hugo.md
+++ b/source/projects/hugo.md
@@ -1,6 +1,6 @@
 ---
 title: Hugo
-repo: spf13/hugo
+repo: gohugoio/hugo
 homepage: http://gohugo.io/
 language: Go
 license: APL 2.0


### PR DESCRIPTION
Hi!

A new GitHub organization `gohugoio` has been created fro Hugo, and thus the Git repository for Hugo has been moved from https://github.com/spf13/hugo to https://github.com/gohugoio/hugo.  The move happened on June 12, 2017.

This pull request updates the repo field from spf13/hugo to gohugoio/hugo.

Many thanks!

Anthony