### PR TITLE
Update _navbar.erb

### DIFF
--- a/source/includes/_navbar.erb
+++ b/source/includes/_navbar.erb
@@ -23,7 +23,7 @@
       <ul>
         <li><a href="/about.html">About StaticGen</a></li>
         <li><a href="/rules.html">The Rules</a></li>
-        <li><a href="https://jamstackcms.com/">Need a Static CMS?</a></li>
+        <li><a href="https://headlesscms.org/">Need a Static CMS?</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
The https://jamstackcms.com's url is redirected to https://headlesscms.org/