### PR TITLE
Add Blackhole

### DIFF
--- a/source/projects/blackhole.md
+++ b/source/projects/blackhole.md
@@ -1,0 +1,17 @@
+---
+title: Blackhole
+repo: BarryMode/grav-plugin-blackhole
+homepage: https://github.com/BarryMode/grav-plugin-blackhole
+language: PHP
+license: MIT
+templates: Twig
+description: Static site generator for Grav CMS
+---
+
+Static site generator for Grav CMS.
+
+### Why use Blackhole?
+
+1. Blackhole is incredibly powerful because you can use Grav as a backend and blackhole to deploy the generated pages routinely.
+1. Benefit from Grav (a dynamic flat-file cms) and the speed and security of a static site, without the manual-ness of a traditional SSG.
+1. Blackhole overcomes the perceived performance limitations of a scaled up live Grav implementation. Tested on sites with more than 20,000 pages.


### PR DESCRIPTION
Here's a pull request to add Blackhole, which is a static site generator for Grav CMS. I see there is another project that does the same sort of thing but for WordPress (called WP Static HTML Output) so I decided to add this one.