### PR TITLE
Add Razzle Material UI Styled Example

### DIFF
--- a/source/projects/razzle-material-ui-styled-example.md
+++ b/source/projects/razzle-material-ui-styled-example.md
@@ -1,0 +1,25 @@
+---
+title: Razzle Material UI Styled Example
+repo: kireerik/razzle-material-ui-styled-example
+homepage: https://github.com/kireerik/razzle-material-ui-styled-example
+language: JavaScript
+license: MIT
+templates: HTML, JavaScript, React.js
+description: Razzle Material UI example with Styled Components using Express with compression. Single route static site generation.
+startertemplaterepo: https://github.com/kireerik/razzle-material-ui-styled-example
+---
+
+<p align="center">
+  Razzle Material UI example with Styled Components using Express with compression
+</p>
+
+## Features
+- <a title="Razzle" href="https://github.com/jaredpalmer/razzle"><img alt="Razzle" src="https://cloud.githubusercontent.com/assets/4060187/26326651/1fc65eca-3f0a-11e7-9f45-02c2bf950418.png" width="" height="18"></a>
+	- **S**erver **S**ide **R**endering
+	- **H**ot **M**odule **R**eplacement for both client and server side <a title="React" href="https://facebook.github.io/react/"><img alt="React" src="https://cdn.worldvectorlogo.com/logos/react.svg" width="" height="18"></a>[React](https://facebook.github.io/react/) components
+	- Up to date JavaScript ([**E**CMA](https://en.wikipedia.org/wiki/Ecma_International)**S**cript 6 (2015)) support
+	- Single route static site generation
+- <a title="Express" href="https://expressjs.com/"><img alt="Express" src="https://cdn.worldvectorlogo.com/logos/express-109.svg" width="" height="18"></a> server with gzip [compression](https://github.com/expressjs/compression)
+	- HTML and inline CSS and JS minification with [HTMLMinifier](https://github.com/kangax/html-minifier)
+	- <a title="Styled Components" href="https://www.styled-components.com/"><img alt="Styled Components" src="https://raw.githubusercontent.com/styled-components/brand/master/styled-components.png" width="18" height="18"></a> [Styled Components](https://www.styled-components.com/)
+	- <a title="Material UI" href="http://www.material-ui.com/#/"><img alt="Material UI" src="https://cdn.worldvectorlogo.com/logos/material-ui.svg" width="" height="18"></a> [Material UI](http://www.material-ui.com/#/)


### PR DESCRIPTION
[Razzle Material UI Styled Example](https://github.com/kireerik/razzle-material-ui-styled-example) has a single route static site generator with server side rendering for React.js. The output is minified without compromises.