### PR TITLE
Make sure '.' only added to filter if other text.

### DIFF
--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -38,8 +38,12 @@ $(function() {
   $('.landing .card').matchHeight();
 
   $("select[name='filter']").change(function(e) {
-    console.log("Filter by: %o", $(this).val());
-    $(".projects").isotope({filter: '.' + $(this).val().replace(/[^A-Z0-9_-]/gi, '\\$&')});
+    var v = $(this).val();
+    console.log("Filter by: %o", v);
+    if (v) {
+      v = '.' + v.replace(/[^A-Z0-9_-]/gi, '\\$&');
+    }
+    $(".projects").isotope({filter: v});
   });
 
   $("select[name='sort']").change(function(e) {


### PR DESCRIPTION
Otherwise filtering just on '.' doesn't work.
Fixes #345.