### PR TITLE
Fix Qgoda project

### DIFF
--- a/content/projects/qgoda.md
+++ b/content/projects/qgoda.md
@@ -2,9 +2,12 @@
 title: Qgoda
 repo: gflohr/qgoda
 homepage: http://www.qgoda.net/
-language: Perl
-license: MIT
-templates: Template Toolkit 2 
+language:
+  - Perl
+license:
+  - MIT
+templates:
+  - Template Toolkit 2 
 description: A sophisticated, blog-aware static site generator with unprecedented multi-language features
 startertemplaterepo: gflohr/qgoda-multilang 
 ---


### PR DESCRIPTION
The Qgoda project was mistakenly merged to the old project file path.

Moved it to the new React Static project file path.