### PR TITLE
Fix missing GitHub stats when slug and key differ

### DIFF
--- a/static.config.js
+++ b/static.config.js
@@ -95,13 +95,11 @@ async function getProjects() {
 
   /**
    * Combine project details from frontmatter and project data from
-   * external sources, using the sluggified title as the link, since
-   * the sluggified titles are used as top level keys in the collected
-   * external data.
+   * external sources, using the project's key derived from its Markdown
+   * filename.
    */
   const projects = projectDetails.map(project => {
-    const slug = toSlug(project.title)
-    const data = projectData[slug]
+    const data = projectData[project.key]
     const fieldValues = pick(project, map(siteConfig.fields, 'name'))
     const mappedProject = mapProjectFrontMatter(project)
     const filteredProject = pickBy({ ...mappedProject, ...data }, val => val)


### PR DESCRIPTION
Use a static site generator project's key instead of its slug to
look up project data.

The key is derived from the Markdown filename for the project. The slug
is derived from the project's title defined in its Markdown file. For
example the project defined in `content/projects/amsf.md` has the title
set to `Almace Scaffolding` in the Markdown file. The key for this
project is `amsf` whereas the slug for this project is
`almace-scaffolding`.

The project data is saved in `projectData` by the project's key. But
prior to this fix, the project's slug is used to look up the data. This
leads to missing GitHub stats for this project and other projects which
have their key different from their slug.

This fix involves looking up a project's data in `projectData` by key
instead of slug.