### PR TITLE
Link to official Gatsby starter template in DTN

### DIFF
--- a/content/projects/gatsby.md
+++ b/content/projects/gatsby.md
@@ -9,7 +9,7 @@ license:
 templates:
   - React
 description: Blazing fast static site generator for React 
-startertemplaterepo: brianstone/gatsby-starter-clean 
+startertemplaterepo: gatsbyjs/gatsby-starter-default
 twitter: gatsbyjs
 ---
 


### PR DESCRIPTION
The starter template linked in the Deploy to Netlify button (https://github.com/brianstone/gatsby-starter-clean) hasn't been updated in 2 years. It still uses gatsby 0.12.6 and reports many security/deprecation warnings during npm install.

This PR changes that template to link to one of the official Gatsby starter templates instead: https://github.com/gatsbyjs/gatsby-starter-default 