### PR TITLE
 Fixed inconsistency - license naming for Publii 

### DIFF
--- a/content/projects/publii.md
+++ b/content/projects/publii.md
@@ -8,9 +8,8 @@ license:
   - GPL 3.0
 templates:
   - Handlebars
-description: desktop-based CMS for Windows and Mac that makes creating static websites fast and hassle-free
+description: Desktop-based CMS for creating static websites.
 twitter: getpublii
-startertemplaterepo: GetPublii/theme-Starter
 ---
 
 

--- a/content/projects/publii.md
+++ b/content/projects/publii.md
@@ -1,0 +1,25 @@
+---
+title: Publii
+repo: GetPublii/Publii
+homepage: https://getpublii.com
+language:
+  - JavaScript
+license:
+  - GPL 3.0
+templates:
+  - Handlebars
+description: desktop-based CMS for Windows and Mac that makes creating static websites fast and hassle-free
+twitter: getpublii
+startertemplaterepo: GetPublii/theme-Starter
+---
+
+
+Publii is a desktop-based CMS for Windows and Mac that makes creating static websites fast and hassle-free, even for beginners.
+
+Unlike static-site generators that are often unwieldy and difficult to use, Publii provides an easy-to-understand UI much like server-based CMSs such as WordPress or Joomla!, where users can create posts and other site content, and style their site using a variety of built-in themes and options. Users can enjoy the benefits of a super-fast and secure static website, with all the convenience that a CMS provides.
+
+What makes Publii even more unique is that the app runs locally on your desktop rather than on the site's server. Available for both Windows and Mac, once the app has been installed you can create a site in minutes, even without internet access; since Publii is a desktop app you can create, update and modify your site offline, then upload the site changes to your server at the click of a button. 
+
+### Supported hostings
+
+Publii supports multiple upload options, including standard HTTP/HTTPS servers, Netlify, Amazon S3, GitHub Pages and Google Cloud or SFTP.

--- a/content/projects/publii.md
+++ b/content/projects/publii.md
@@ -5,7 +5,7 @@ homepage: https://getpublii.com
 language:
   - JavaScript
 license:
-  - GPL 3.0
+  - GNU GPL v3.0
 templates:
   - Handlebars
 description: Desktop-based CMS for creating static websites.


### PR DESCRIPTION
All projects are using GNU GPL 3.0 what causes that on the licenses list we have now `GNU GPL 3.0` and `GPL 3.0`