### PR TITLE
Replace "Jinja 2" with "Jinja2" in PyKwiki

### DIFF
--- a/content/projects/pykwiki.md
+++ b/content/projects/pykwiki.md
@@ -7,7 +7,7 @@ language:
 license:
   - MIT
 templates:
-  - Jinja 2
+  - Jinja2
 description: Markdown based authoring with static search. 
 ---
 


### PR DESCRIPTION
"Jinja 2" was wrongly set as the template, since all others
use "Jinja2" (no space). This led to having two templates for
the same thing in the filter dropdown.