### PR TITLE
Replace Hastie Go templates with Go

### DIFF
--- a/content/projects/hastie.md
+++ b/content/projects/hastie.md
@@ -7,7 +7,7 @@ language:
 license:
   - MIT
 templates:
-  - Go templates
+  - Go
 description: A static site generator written in Go
 ---
 


### PR DESCRIPTION
I think Go templates is the same as Go, right? If I'm mistaken, ignore this :)