### PR TITLE
Added startertemplaterepo to the CMintS as part of JAMstack Hackathon

### DIFF
--- a/content/projects/cmints.md
+++ b/content/projects/cmints.md
@@ -9,6 +9,7 @@ license:
 templates:
   - EJS
 description: CMS and Static Site Generator created with the internationalization in mind.
+startertemplaterepo: Manvel/cmints-website
 ---
 
 CMintS is a CMS and Static Site Generator that has been implemented with the


### PR DESCRIPTION
This is a followup to the [current discussion](https://github.com/netlify/staticgen/pull/407#discussion_r211713505).

Currently the `startertemplaterepo` contains the build script and also `netlify.toml` file.

There is also a guide how to deploy CMintS application to the Netlify see -> https://cmints.io/en/documentation/getting-started/deployment

This PR is part of the [JAMstack Hackathon](https://github.com/freeCodeCamp/2018-online-jamstack-hackathon/blob/master/teams.md#cmints), so I will highly appreciate if current PR will get an attention before the Hackathon deadline.

Thanks in advance.