### PR TITLE
Rename gutenberg to zola

### DIFF
--- a/content/projects/zola.md
+++ b/content/projects/zola.md
@@ -1,7 +1,7 @@
 ---
-title: Gutenberg
-repo: Keats/gutenberg
-homepage: https://www.getgutenberg.io/
+title: Zola
+repo: getzola/zola
+homepage: https://www.getzola.org/
 language:
   - Rust
 license:
@@ -20,3 +20,4 @@ Static site generator built using the modern Rust programming language.
 * Built-in support for themes
 * Code highlighting themes
 * Tera template engine, and built-in shortcodes
+


### PR DESCRIPTION
The 'gutenberg' static site generator project changed its name to 'zola'
to avoid a name collision with a popular wordpress-related project.
This commit reflects this change in the project name.