### PR TITLE
Metabake typos fix

### DIFF
--- a/content/projects/metabake.md
+++ b/content/projects/metabake.md
@@ -1,11 +1,11 @@
 ---
-title: Metabake.org
-repo: metabake
-homepage: http://www.metabake.org
+title: Metabake
+repo: metabake/_mbake-CLI-for-Metabake
+homepage: http://www.metabake.net
 language: JavaScript
 license: MIT
 templates: Pug and Markdown
-description: 10 times more productive web app development via low code such as Pug
+description: Low-code for programmer via generators for Pug, Markdown and much more; including dynamic data binding
 ---
 
 Metabake mbake CLI lets you generate websites and dynamic webapps in Pug by leveraging low code pillars for high development productivity.
@@ -38,15 +38,17 @@ key1: World
 mbake .
 ```
 
-This will create index.html. Of course you can use regular Pug syntax to include markdown with CSS support:
+This will create index.html. 
+
+Of course you can use regular Pug syntax to include other Pug files; or Markdown. Metabake Markdown flavor includes CSS support:
 ```pug
     include:metaMDtf comment.md
 ```
 
 ## Home Page
 
-There is also an admin module, a watcher module, Hybrida mobile apps, SPA, Blog, Website, CRUD, PWA, Electron, Cloud v2.0 via AWS|FireStore, RIOTjs and more. 
+Examples include an admin module, a watcher module,SPA, Blog, Website, CRUD, PWA, Electron,  Hybrid mobile apps, Cloud v2.0 via AWS|FireStore, RIOTjs and more. 
 Primary focus is high development productivity (via "low code") and being easy to learn. But it is also fully flexibile to build any webapp in any directory tree structure you like an use any CSS/SASS framework you like.
-Metabake supports css classes in markdown, plus, because it uses Pug - it can also do any html layout. But metabake is not static only - it fully supports and has examples and docs for dynamic apps.
+Metabake supports CSS classes in Markdown, plus, because it uses Pug - it can also do any HTML layout. But Metabake is not static only - it fully supports and has examples and docs for dynamic apps.
 
-[Metabake.org](http://www.metabake.org)
+[Metabake.net](http://www.metabake.net)

--- a/content/projects/metabake.md
+++ b/content/projects/metabake.md
@@ -5,7 +5,7 @@ homepage: http://www.metabake.net
 language: JavaScript
 license: MIT
 templates: Pug and Markdown
-description: Low-code for programmer via generators for Pug, Markdown and much more; including dynamic data binding
+description: Low-code productivity for programmer via generators for Pug, Markdown and much more; including dynamic data binding.
 ---
 
 Metabake mbake CLI lets you generate websites and dynamic webapps in Pug by leveraging low code pillars for high development productivity.

--- a/content/projects/metabake.md
+++ b/content/projects/metabake.md
@@ -5,7 +5,7 @@ homepage: http://www.metabake.net
 language: JavaScript
 license: MIT
 templates: Pug and Markdown
-description: Low-code productivity for programmer via generators for Pug, Markdown and much more; including dynamic data binding.
+description: Low-code productivity for programmers via generators for Pug, Markdown and much more; including dynamic data binding.
 ---
 
 Metabake mbake CLI lets you generate websites and dynamic webapps in Pug by leveraging low code pillars for high development productivity.


### PR DESCRIPTION
I am fixing some text and fixing the link to the GitHub project page.

I did not realize that when I rename the project the links are lost.