### PR TITLE
MINOR: changing "Vue.Js" to "Vue" to keep it consistent

### DIFF
--- a/content/projects/gridsome.md
+++ b/content/projects/gridsome.md
@@ -7,7 +7,7 @@ language:
 license:
   - MIT
 templates:
-  - Vue.js
+  - Vue
 description: Build blazing fast websites for any CMS or data with Vue.js
 startertemplaterepo: gridsome/gridsome-starter-default
 twitter: gridsome


### PR DESCRIPTION
Currently Vue and Vue.js are a double up. This PR should fix this.