### PR TITLE
fix: github repo shouldn't include github.com

### DIFF
--- a/content/projects/stasis-generator.md
+++ b/content/projects/stasis-generator.md
@@ -1,6 +1,6 @@
 ---
 title: Stasis
-repo: https://github.com/Gioni06/stasis-generator
+repo: Gioni06/stasis-generator
 homepage: https://getstasis.com/
 language:
   - Typescript
@@ -9,7 +9,7 @@ license:
 templates:
   - Handlebars
 description: A static site generator that is simple and easy to use.
-startertemplaterepo: https://github.com/Gioni06/stasis-basic-example
+startertemplaterepo: Gioni06/stasis-basic-example
 ---
 
 Stasis is a simple and easy to use static site generator. It aims to provide production ready tools to create static website projects.


### PR DESCRIPTION
including the hostname in these fields duplicates the hostname in the generated links.
causes the links to display: https://github.com/https://github.com/Gioni06/stasis-generator instead of https://github.com/Gioni06/stasis-generator. This PR fixes the links.