### PR TITLE
resolves #510 add support for projects hosted on GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ npm install
 npm start
 ```
 
-In order to successfully retrieve Twitter followers and GitHub stars, you will need authentication
-keys for both services.
+In order to successfully retrieve Twitter followers and repository stars (GitHub or GitLab), you
+will need authentication keys for these services.
 
-For GitHub, all you'll need is a personal access token. This can be generated at
-<https://github.com/settings/tokens>. For Twitter, you need to create an application at
-<https://apps.twitter.com> to get the necessary tokens. When deploying, you must set the environment
-variables per the example below. If you are developing locally, you can set
-these in a `.env` file at the root of the repo.
+For GitHub, all you'll need is a personal access token with the repo and gist scopes. This can be
+generated at <https://github.com/settings/tokens>. For GitLab, you'll also need a personal access
+token. This can be generated at <https://gitlab.com/profile/personal_access_tokens>. For Twitter,
+you need to create an application at <https://apps.twitter.com> to get the necessary tokens. When
+deploying, you must set the environment variables per the example below. If you are developing
+locally, you can set these in a `.env` file at the root of the repo.
 
 ```
 STATICGEN_GITHUB_TOKEN=examplekey123abc
@@ -42,9 +43,9 @@ STATICGEN_TWITTER_ACCESS_TOKEN_KEY=examplekey231abc
 STATICGEN_TWITTER_ACCESS_TOKEN_SECRET=examplekey321abc
 ```
 
-GitHub and Twitter data is cached in the `.tmp` directory, and online in a Gist. If neither has data
-newer than 24 hours old, fresh data is fetched from GitHub and Twitter. Fetching caching occur
-automatically during the build.
+GitHub, GitLab, and Twitter data is cached in the `.tmp` directory, and online in a Gist. If neither
+has data newer than 24 hours old, fresh data is fetched from GitHub, GitLab, and Twitter. Fetching
+caching occur automatically during the build.
 
 Then visit http://localhost:3000/ - React Static will automatically reload when changes occur.
 

--- a/content/projects/antora.md
+++ b/content/projects/antora.md
@@ -1,0 +1,42 @@
+---
+title: Antora
+repo: antora/antora
+repohost: gitlab
+homepage: https://antora.org
+language:
+  - JavaScript
+license:
+  - MPL-2.0
+templates:
+  - Handlebars
+description: A multi-repository documentation site generator for tech writers who love writing in AsciiDoc.
+twitter: antoraproject
+---
+
+### Overview
+
+Antora is a modular, multi-repository site generator designed for producing documentation sites from content composed in AsciiDoc and converted to HTML using Asciidoctor and Handlebars.
+
+Antora provides both a toolchain and workflow to help documentation and engineering teams create, manage, collaborate on, remix, and publish documentation sites aggregated from multi-branch git repositories without needing expertise in web technologies, build automation, or system administration.
+
+### Who it's for
+
+Tech writers, first and foremost.
+
+If you're already using Asciidoctor, and you need help managing a large set of documentation written in AsciiDoc, Antora was designed for you.
+If you haven't yet tried Asciidoctor (or AsciiDoc), Antora is a great way to get started because it provides everything you need to start writing and publishing documentation today.
+
+### What it includes
+
+Antora includes a command line interface (CLI) (command: antora), a preassembled site generator pipeline, and a default UI so you can get started quickly publishing documentation sites with Antora.
+
+Since Antora is both modular and extensible, there are plenty of opportunities to explore to take it further once you have your first site up and running.
+
+### Availability
+
+Antora is available as a suite of npm packages and a Docker image.
+Antora runs on any platform that supports Node, which includes Linux, macOS, and Windows.
+
+### Learn more
+
+To learn more about Antora, be sure to check out the [documentation](https://docs.antora.org), which, as you would expect, is published by Antora itself.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@octokit/rest": "^14.0.9",
     "date-fns": "^1.29.0",
     "dotenv": "^5.0.0",
+    "gitlab": "^5.0.1",
     "gray-matter": "^3.1.1",
     "js-yaml": "^3.11.0",
     "marked": "^0.3.14",

--- a/scripts/fetch-archive.js
+++ b/scripts/fetch-archive.js
@@ -1,14 +1,16 @@
 import path from 'path'
 import fs from 'fs-extra'
-import { map, find, fromPairs, mapValues } from 'lodash'
+import { compact, map, find, fromPairs, mapValues } from 'lodash'
 import fetch from 'node-fetch'
 import { differenceInMinutes } from 'date-fns'
 import Octokit from '@octokit/rest'
+import { Gitlab } from 'gitlab'
 import twitterFollowersCount from 'twitter-followers-count'
 
 require('dotenv').config()
 
 const GITHUB_TOKEN = process.env.STATICGEN_GITHUB_TOKEN
+const GITLAB_TOKEN = process.env.STATICGEN_GITLAB_TOKEN
 const TWITTER_CONSUMER_KEY = process.env.STATICGEN_TWITTER_CONSUMER_KEY
 const TWITTER_CONSUMER_SECRET = process.env.STATICGEN_TWITTER_CONSUMER_SECRET
 const TWITTER_ACCESS_TOKEN_KEY = process.env.STATICGEN_TWITTER_ACCESS_TOKEN_KEY
@@ -18,11 +20,13 @@ const LOCAL_ARCHIVE_PATH = `tmp/${ARCHIVE_FILENAME}`
 const GIST_ARCHIVE_DESCRIPTION = 'STATICGEN.COM DATA ARCHIVE'
 
 let octokit
+let gitlab
 let getTwitterFollowers
 
 function authenticate () {
   octokit = Octokit()
   octokit.authenticate({ type: 'token', token: GITHUB_TOKEN })
+  gitlab = new Gitlab({ personaltoken: GITLAB_TOKEN })
   getTwitterFollowers = twitterFollowersCount({
     consumer_key: TWITTER_CONSUMER_KEY,
     consumer_secret: TWITTER_CONSUMER_SECRET,
@@ -34,22 +38,35 @@ function authenticate () {
 async function getProjectGitHubData (repo) {
   const [owner, repoName] = repo.split('/')
   const { data } = await octokit.repos.get({ owner, repo: repoName })
-  const { stargazers_count, forks_count, open_issues_count } = data
-  return { stars: stargazers_count, forks: forks_count, issues: open_issues_count }
+  const { stargazers_count, forks_count, open_issues_count, html_url } = data
+  return { stars: stargazers_count, forks: forks_count, issues: open_issues_count, repo: html_url }
 }
 
-async function getAllProjectGitHubData (repos) {
+async function getProjectGitLabData (repo) {
+  const { id, star_count, forks_count, web_url } = await gitlab.Projects.show(repo)
+  const open_issues_count = (await gitlab.Issues.all({ projectId: id, state: 'opened' })).length
+  return { stars: star_count, forks: forks_count, issues: open_issues_count, repo: web_url }
+}
+
+async function getAllProjectRepoData (repos) {
   const data = []
   // eslint-disable-next-line no-restricted-syntax
-  for (const repo of repos) {
+  for (const repoWithHost of repos) {
+    const [repoHost, repo] = repoWithHost.split(':')
     // eslint-disable-next-line no-await-in-loop
     await new Promise(res => setTimeout(res, 100))
     try {
-      // eslint-disable-next-line no-await-in-loop
-      const repoData = await getProjectGitHubData(repo)
-      data.push([repo, repoData])
+      if (repoHost === 'gitlab') {
+        // eslint-disable-next-line no-await-in-loop
+        const repoData = await getProjectGitLabData(repo)
+        data.push([repoWithHost, repoData])
+      } else {
+        // eslint-disable-next-line no-await-in-loop
+        const repoData = await getProjectGitHubData(repo)
+        data.push([repoWithHost, repoData])
+      }
     } catch (err) {
-      console.error(`Could not load repository "${repo}". Please make sure it still exists.`)
+      console.error(`Could not load repository "${repo}" from ${repoHost}. Please make sure it still exists.`)
     }
   }
   return fromPairs(data)
@@ -57,15 +74,14 @@ async function getAllProjectGitHubData (repos) {
 
 async function getAllProjectData (projects) {
   const timestamp = Date.now()
-  const twitterScreenNames = map(projects, 'twitter').filter(val => val)
-  const twitterFollowers = twitterScreenNames.length &&
-    await getTwitterFollowers(twitterScreenNames)
-  const gitHubRepos = map(projects, 'repo').filter(val => val)
-  const gitHubReposData = await getAllProjectGitHubData(gitHubRepos)
-  const data = projects.reduce((obj, { key, repo, twitter }) => {
+  const twitterScreenNames = compact(map(projects, 'twitter'))
+  const twitterFollowers = twitterScreenNames.length && await getTwitterFollowers(twitterScreenNames)
+  const repos = compact(map(projects, val => val.repo ? [val.repohost || 'github', val.repo].join(':') : undefined))
+  const reposData = await getAllProjectRepoData(repos)
+  const data = projects.reduce((obj, { key, repo, repohost, twitter }) => {
     const twitterData = twitter ? { followers: twitterFollowers[twitter] } : {}
-    const gitHubData = repo ? { ...(gitHubReposData[repo]) } : {}
-    return { ...obj, [key]: [{ timestamp, ...twitterData, ...gitHubData }] }
+    const repoData = repo ? { ...(reposData[[repohost || 'github', repo].join(':')]) } : {}
+    return { ...obj, [key]: [{ timestamp, ...twitterData, ...repoData }] }
   }, {})
   return { timestamp, data }
 }

--- a/site.yaml
+++ b/site.yaml
@@ -16,7 +16,7 @@ navLinks:
   - { url: https://jamstack.org, text: About JAMstack }
   - { url: https://headlesscms.org, text: Need a Static CMS? }
 sorts:
-  - { field: "stars", label: "GitHub stars", reverse: true }
+  - { field: "stars", label: "Repo stars", reverse: true }
   - { field: "followers", label: "Twitter followers", reverse: true }
   - { field: "title", label: "Title" }
 filters:

--- a/src/Home/DeployButton.js
+++ b/src/Home/DeployButton.js
@@ -5,7 +5,7 @@ import netlifyLogo from 'Images/netlify-logo.svg'
 const DeployButton = styled(({ repo, className }) => (
   <a
     className={className}
-    href={`https://app.netlify.com/start/deploy?repository=https://github.com/${repo}`}
+    href={`https://app.netlify.com/start/deploy?repository=${repo}`}
   >
     <img alt="" src={netlifyLogo} /> Deploy to Netlify
   </a>

--- a/src/Home/Project.js
+++ b/src/Home/Project.js
@@ -40,7 +40,7 @@ const Project = ({
       <OpenSourceStat
         key="stars"
         Icon={() => <Octicon name="star" zoom="100%" />}
-        label="GitHub stars"
+        label="Repo stars"
         value={stars}
         change={stars - starsPrevious}
         indicateColor
@@ -49,7 +49,7 @@ const Project = ({
       <OpenSourceStat
         key="issues"
         Icon={() => <Octicon name="issue-opened" zoom="100%" />}
-        label="GitHub open issues"
+        label="Open issues"
         value={issues}
         change={issues - issuesPrevious}
         dataAgeInDays={dataAgeInDays}
@@ -57,7 +57,7 @@ const Project = ({
       <OpenSourceStat
         key="forks"
         Icon={() => <Octicon name="repo-forked" zoom="100%" />}
-        label="GitHub forks"
+        label="Repo forks"
         value={forks}
         change={forks - forksPrevious}
         indicateColor

--- a/src/Project/Project.js
+++ b/src/Project/Project.js
@@ -97,8 +97,8 @@ class Project extends React.Component {
               </DetailLink>
             }
             {repo &&
-              <DetailLink href={`https://github.com/${repo}`}>
-                <EntypoIcon Icon={EntypoGithub} /> https://github.com/{repo} ({stars})
+              <DetailLink href={repo}>
+                <EntypoIcon Icon={EntypoGithub} /> {repo} ({stars})
               </DetailLink>
             }
           </div>

--- a/static.config.js
+++ b/static.config.js
@@ -31,20 +31,31 @@ function processMarkdown (markdown, key) {
 function mapProjectFrontMatter ({
   title,
   repo,
+  repohost,
   homepage,
   description,
   startertemplaterepo,
   content,
   twitter,
 }) {
+  const repoHost = repohost || 'github'
+  let starterTemplateRepo = startertemplaterepo
+  if (starterTemplateRepo && !starterTemplateRepo.includes(':')) {
+    if (repoHost === 'github') {
+      starterTemplateRepo = `https://github.com/${starterTemplateRepo}`
+    } else if (repoHost === 'gitlab') {
+      starterTemplateRepo = `https://gitlab.com/${starterTemplateRepo}`
+    }
+  }
   return {
     title,
     slug: toSlug(title),
     repo,
+    repoHost,
     homepage,
     twitter,
     description,
-    starterTemplateRepo: startertemplaterepo,
+    starterTemplateRepo,
     content,
   }
 }
@@ -56,7 +67,7 @@ function extractRelevantProjectData (data) {
     const oldestTimestamp = dateFns.min(...timestamps).getTime()
     const dataAgeInDays = dateFns.differenceInDays(Date.now(), oldestTimestamp)
     const {
-      followers, forks, stars, issues,
+      followers, forks, stars, issues, repo
     } = find(project, { timestamp: newestTimestamp }) || {}
     const {
       forks: forksPrevious,
@@ -64,7 +75,7 @@ function extractRelevantProjectData (data) {
       issues: issuesPrevious,
       followers: followersPrevious,
     } = find(project, { timestamp: oldestTimestamp }) || {}
-    return {
+    const relevantData = {
       followers,
       forks,
       stars,
@@ -75,6 +86,8 @@ function extractRelevantProjectData (data) {
       followersPrevious,
       dataAgeInDays,
     }
+    if (repo) relevantData.repo = repo
+    return relevantData
   })
 }
 


### PR DESCRIPTION
This PR adds support for projects hosted on GitLab, including star count.

~Due to how the GitLab API works, it's necessary to specify the repo using the ID instead of the path. The repo property in the front matter must be defined as follows:~

```
repo: gitlab:4180516
```

UPDATE: This PR now implements a separate repohost field. And we found out that the GitLab API accepts a repo path as well. So now the configuration is:

```
repo: antora/antora
repohost: gitlab
```

The repo will get replaced with the URL returned from the API.

In order to use these changes, it's necessary to:

1. run `npm i` to get the new package
2. set the STATICGEN_GITLAB_TOKEN environment variable to a personal access token
3. remove and rebuild the staticgen-archive.json file

I also found I had to update react to at least 16.3.0 to get the site to build without error. (UPDATE: This can be avoided by installing packages using yarn).