### PR TITLE
updated inkPaper info

### DIFF
--- a/content/projects/inkpaper.md
+++ b/content/projects/inkpaper.md
@@ -1,12 +1,13 @@
 ---
 title: InkPaper
 repo: InkProject/ink
-homepage: http://www.chole.io/
+homepage: https://imeoer.github.io
 language:
   - Go
 license:
   - MIT
 templates:
+  - Markdown
   - Go
 description: 'InkPaper is an elegant, extremely fast static blog generator.'
 ---


### PR DESCRIPTION
- old website expired, so they moved to gh-pages
- markdown is supported directly