### PR TITLE
Add Staart Site

### DIFF
--- a/content/projects/staart-site.md
+++ b/content/projects/staart-site.md
@@ -1,0 +1,21 @@
+--
+title: Staart Site
+repo: staart/site
+homepage: https://staart.js.org/site
+language:
+  - JavaScript
+  - TypeScript
+license:
+  - MIT
+templates:
+  - Handlebars
+description: SSG for docs that creates ultra-lightweight, 100/100 Lighthouse websites
+---
+
+## About Staart Site
+
+Staart Site is a static site generator for helpdesk or documentation websites written in TypeScript. It creates beautiful, accessible, and ultra-lightweight websites that score 100/100 on Lightbox.
+
+It has no configuration required (deploys Markdown files from your `content` folder), including "last modified in commit" links to GitHub. Also generates schema data for SEO, sitemaps, and Shields badges schema. It's incredibly lightweight, at just 1.2kb minzipped CSS for both light and dark themes.
+
+Staart Site is part of [Staart](https://staart.js.org), a set of starter templates written in TypeScript to build SaaS startups, including backend, PWA, and app starters.  


### PR DESCRIPTION
Staart Site is a static site generator for helpdesk or documentation websites written in TypeScript. It creates beautiful, accessible, and ultra-lightweight websites that score 100/100 on Lightbox.