### PR TITLE
Add two static site generators based on R

### DIFF
--- a/content/projects/blogdown-r.md
+++ b/content/projects/blogdown-r.md
@@ -1,0 +1,43 @@
+---
+title: Blogdown
+repo: rstudio/blogdown
+homepage: https://bookdown.org/yihui/blogdown
+language:
+  - R
+license:
+  - GPL-3
+templates:
+  - R, R Markdown
+description: Create Blogs and Websites with R Markdown
+---
+
+[![Build Status](https://travis-ci.org/rstudio/blogdown.svg)](https://travis-ci.org/rstudio/blogdown)
+[![Coverage status](https://codecov.io/gh/rstudio/blogdown/branch/master/graph/badge.svg)](https://codecov.io/github/rstudio/blogdown?branch=master)
+[![Downloads from the RStudio CRAN mirror](https://cranlogs.r-pkg.org/badges/blogdown)](https://cran.r-project.org/package=blogdown)
+
+<a href="https://bookdown.org/yihui/blogdown"><img src="https://bookdown.org/yihui/blogdown/images/logo.png" alt="blogdown logo" align="right" /></a>
+
+An open-source (GPL-3) R package to generate static websites based on [R Markdown](https://rmarkdown.rstudio.com) and [Hugo](https://gohugo.io). You can install the package via CRAN or GitHub:
+
+```r
+## Install from CRAN
+install.packages('blogdown')
+
+## Or, install from GitHub
+remotes::install_github('rstudio/blogdown')
+```
+
+You may create a new site via the function `blogdown::new_site()` under an _empty_ directory. It will create a skeleton site, download a Hugo theme from Github,  add some sample content, launch a web browser and you will see the new site. The sample blog post `hello-world.Rmd` should be opened automatically, and you can edit it. The website will be automatically rebuilt and the page will be refreshed after you save the file.
+
+If you use RStudio, you can create a new RStudio project for your website from the menu `File -> New Project -> New Directory -> Website using blogdown`.
+
+The function `blogdown::serve_site()` may be the most frequently used function in this package. It builds the website, loads it into your web browser, and automatically refreshes the browser when you update the Markdown or R Markdown files. Do not use the command line `hugo server` to build or serve the site. It only understands plain Markdown files, and cannot build R Markdown.
+
+You may not be satisfied with the default site created from `new_site()`. There are two things you may want to do after your first successful experiment with **blogdown**:
+
+1. Pick a Hugo theme that you like from http://themes.gohugo.io. All you need is its Github user and repository name, to be passed to the `theme` argument of `new_site()`.
+2. Add more content (pages or posts), or migrate your existing website.
+
+The full documentation is the **blogdown** book freely available at https://bookdown.org/yihui/blogdown/. You are expected to read at least the first chapter. 
+You are welcome to send us feedback using [Github issues](https://github.com/rstudio/blogdown/issues) or ask questions on [StackOverflow](http://stackoverflow.com/questions/tagged/blogdown) with the `blogdown` tag.
+

--- a/content/projects/rmarkdown.md
+++ b/content/projects/rmarkdown.md
@@ -1,0 +1,77 @@
+---
+title: R Markdown
+repo: rstudio/rmarkdown
+homepage: https://rmarkdown.rstudio.com/
+language:
+  - R
+license:
+  - GPL-3
+templates:
+  - R, R Markdown
+description: Dynamic Documents for R
+---
+
+[![Build Status](https://travis-ci.org/rstudio/rmarkdown.svg?branch=master)](https://travis-ci.org/rstudio/rmarkdown)
+[![Downloads from the RStudio CRAN mirror](https://cranlogs.r-pkg.org/badges/rmarkdown)](https://cran.r-project.org/package=rmarkdown)
+
+The **rmarkdown** package helps you create dynamic analysis documents that combine code, rendered output (such as figures), and prose. You bring your data, code, and ideas, and R Markdown renders your content into a polished document that can be used to:
+
+<img src="https://bookdown.org/yihui/rmarkdown/images/hex-rmarkdown.png" alt="The rmarkddown hex sticker" width="200" style="padding: 0 15px; float: right;"/>
+
+- Do data science interactively within the RStudio IDE,
+
+- Reproduce your analyses,
+
+- Collaborate and share code with others, and
+
+- Communicate your results with others.
+
+R Markdown documents can be rendered to many output formats including HTML documents, PDFs, Word files, slideshows, and more, allowing you to focus on the content while R Markdown takes care of your presentation. 
+
+
+### Installation
+
+The easiest way to install the **rmarkdown** package is from within the [RStudio IDE](http://www.rstudio.com/ide/download/preview), but you don't need to explicitly install it or load it, as RStudio automatically does both when needed. A recent version of Pandoc (>= 1.12.3) is also required; RStudio also automatically includes this too so you do not need to download Pandoc if you plan to use rmarkdown from the RStudio IDE.
+
+If you want to use the rmarkdown package outside of RStudio, you can install the package from CRAN as follows:
+
+```r
+install.packages("rmarkdown")
+```
+
+If you want to use the development version of the rmarkdown package (either with or without RStudio), you can install the package from GitHub via the [**remotes** package](https://remotes.r-lib.org):
+
+```r
+remotes::install_github('rstudio/rmarkdown')
+```
+
+If not using the RStudio IDE, you'll need to install a recent version of Pandoc (>= 1.12.3); see the [Pandoc installation instructions](https://rmarkdown.rstudio.com/docs/articles/pandoc.html) for help.
+
+### Usage
+
+The easiest way to make a new R Markdown document is from within RStudio. Go to _File > New File > R Markdown_. From the new file wizard, you may:
+
++ Provide a document title (_optional but recommended_),
++ Provide an author name (_optional but recommended_),
++ Select a default output format- HTML is the recommended format for authoring, and you can switch the output format anytime (_required_), 
++ Click **OK** (_required_).
+
+Once inside your new `.Rmd` file, you should see some boilerplate text that includes code chunks. Use the "Knit" button in the RStudio IDE to render the file and preview the output with a single click or use the keyboard shortcut Cmd/Ctrl + Shift + K. 
+
+You can also delete all the text below the YAML frontmatter and fill in your own `.Rmd` by:
+
++ Adding code chunks (keyboard shortcut: `Ctrl + Alt + I`; OS X: `Cmd + Option + I`),
++ Writing prose with [Markdown formatting](https://www.markdowntutorial.com/), and
++ Running each code chunk interactively by clicking the ![The run button](https://rmarkdown.rstudio.com/images/notebook-run-chunk.png) icon within RStudio. 
+
+You can also click "Knit to HTML" again to render the full document with all code chunks. For more help getting started in R Markdown, please see the [R Markdown website](https://rmarkdown.rstudio.com/lesson-1.html) or use the **"Get Started"** links at the top of this page.
+
+### Getting help
+
+There are two main places to get help:
+
+1. The [RStudio community](https://community.rstudio.com/c/R-Markdown) is a friendly place to ask any questions about rmarkdown and the R Markdown family of packages.
+
+1. [Stack Overflow](https://stackoverflow.com/questions/tagged/r-markdown) is a great source of answers to common rmarkdown questions. It is also a great place to get help, once you have created a reproducible example that illustrates your problem.
+
+


### PR DESCRIPTION
This PR adds two static site generators based on R:

- [R Markdown websites](https://rmarkdown.rstudio.com/formats.html)
- [Blogdown](https://bookdown.org/yihui/blogdown/)