### PR TITLE
Updating links to Svelte and Sapper's newer domain

### DIFF
--- a/content/projects/sapper.md
+++ b/content/projects/sapper.md
@@ -1,7 +1,7 @@
 ---
 title: Sapper.js
 repo: sveltejs/sapper
-homepage: https://sapper.svelte.technology
+homepage: https://sapper.svelte.dev
 language:
   - JavaScript
 license:
@@ -12,6 +12,6 @@ description: Sapper is a framework for building high-performance universal web a
 startertemplaterepo: sveltejs/sapper-template
 ---
 
-Sapper is a framework for building high-performance universal web apps. [Read the guide](https://sapper.svelte.technology/guide) or the [introductory blog post](https://svelte.technology/blog/sapper-towards-the-ideal-web-app-framework) to learn more.
+Sapper is a framework for building high-performance universal web apps. [Read the guide](https://sapper.svelte.dev/docs) or the [introductory blog post](https://svelte.dev/blog/sapper-towards-the-ideal-web-app-framework) to learn more.
 
-It's like Next.js and Nuxt.js, but faster and smaller because it's powered by [Svelte](https://svelte.technology).
+It's like Next.js and Nuxt.js, but faster and smaller because it's powered by [Svelte](https://svelte.dev).


### PR DESCRIPTION
Svelte is now found at svelte.dev, and Sapper is at sapper.svelte.dev