### PR TITLE
Quick-and-dirty bugfix to restore git provider to repo URLs to fix Deploy To Netlify button functionality

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,7 +31,7 @@ function extractRelevantProjectData(data, configDays) {
   })
 }
 
-export function getStarterTemplateRepoUrl(repo, repoHost = 'github') {
+exports.getStarterTemplateRepoUrl = (repo, repoHost = 'github') => {
   if (!repo) {
     return
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,18 +31,6 @@ function extractRelevantProjectData(data, configDays) {
   })
 }
 
-exports.getStarterTemplateRepoUrl = (repo, repoHost = 'github') => {
-  if (!repo) {
-    return
-  }
-  switch (repoHost) {
-    case 'github':
-      return `https://github.com/${repo}`
-    case 'gitlab':
-      return `https://gitlab.com/${repo}`
-  }
-}
-
 exports.sourceNodes = async ({
   graphql,
   actions,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -31,7 +31,7 @@ function extractRelevantProjectData(data, configDays) {
   })
 }
 
-function getStarterTemplateRepoUrl(repo, repoHost = 'github') {
+export function getStarterTemplateRepoUrl(repo, repoHost = 'github') {
   if (!repo) {
     return
   }

--- a/src/components/projectcard.js
+++ b/src/components/projectcard.js
@@ -6,7 +6,6 @@ import { EntypoTwitter } from 'react-entypo'
 import Stat from './stat'
 import DeployButton from './deploybutton'
 import DataPoint from './datapoint'
-import { getStarterTemplateRepoUrl } from "../../gatsby-node.js";
 
 const TwitterIcon = styled(EntypoTwitter)`
   width: 16px !important;
@@ -45,6 +44,18 @@ const CardBodyLink = styled(Link)`
     text-decoration: none;
   }
 `
+
+function getStarterTemplateRepoUrl(repo, repoHost = 'github') {
+  if (!repo) {
+    return
+  }
+  switch (repoHost) {
+    case 'github':
+      return `https://github.com/${repo}`
+    case 'gitlab':
+      return `https://gitlab.com/${repo}`
+  }
+}
 
 const Title = styled.h4`
   margin: 0 -18px 0px;

--- a/src/components/projectcard.js
+++ b/src/components/projectcard.js
@@ -136,9 +136,23 @@ const Card = props => {
           <DataPoint key={field.name} value={props[field.name]} label={field.label} />
         ))}
       </CardBodyLink>
-      {startertemplaterepo && <DeployButton repo={startertemplaterepo} />}
+      {startertemplaterepo && (
+        <DeployButton repo={getStarterTemplateRepoUrl(startertemplaterepo)} />
+      )}
     </CardContainer>
   )
+}
+
+function getStarterTemplateRepoUrl(repo, repoHost = 'github') {
+  if (!repo) {
+    return
+  }
+  switch (repoHost) {
+    case 'github':
+      return `https://github.com/${repo}`
+    case 'gitlab':
+      return `https://gitlab.com/${repo}`
+  }
 }
 
 export default Card

--- a/src/components/projectcard.js
+++ b/src/components/projectcard.js
@@ -6,6 +6,7 @@ import { EntypoTwitter } from 'react-entypo'
 import Stat from './stat'
 import DeployButton from './deploybutton'
 import DataPoint from './datapoint'
+import { getStarterTemplateRepoUrl } from "../../gatsby-node.js";
 
 const TwitterIcon = styled(EntypoTwitter)`
   width: 16px !important;
@@ -141,18 +142,6 @@ const Card = props => {
       )}
     </CardContainer>
   )
-}
-
-function getStarterTemplateRepoUrl(repo, repoHost = 'github') {
-  if (!repo) {
-    return
-  }
-  switch (repoHost) {
-    case 'github':
-      return `https://github.com/${repo}`
-    case 'gitlab':
-      return `https://gitlab.com/${repo}`
-  }
 }
 
 export default Card

--- a/src/components/projectcard.js
+++ b/src/components/projectcard.js
@@ -14,6 +14,7 @@ const TwitterIcon = styled(EntypoTwitter)`
 
 const CardContainer = styled.div`
   background: #fff;
+  
   border: 1px solid #eee;
   border-radius: 8px;
   color: #313d3e;

--- a/src/components/projectcard.js
+++ b/src/components/projectcard.js
@@ -14,7 +14,6 @@ const TwitterIcon = styled(EntypoTwitter)`
 
 const CardContainer = styled.div`
   background: #fff;
-  
   border: 1px solid #eee;
   border-radius: 8px;
   color: #313d3e;


### PR DESCRIPTION
@fool reported a high priority bug in `react-ui` related to broken Deploy To Netlify buttons https://github.com/netlify/netlify-react-ui/issues/3782.

After some digging, it seems the build errors were only happening when the DTN button was clicked from staticgen.com, and not directly from a Git repo (for example: https://github.com/netlify-templates/gatsby-starter-netlify-cms).

We couldn’t get staticgen.com to run locally (GraphQL errors), but from what we can tell, the problem traces back to this helper that is no longer being used to format the repo URL: https://github.com/netlify/staticgen/blob/master/gatsby-node.js#L34

This PR is a quick fix to get *most* of the DTN buttons working again. This should be cleaned up and fixed eventually 🙂 