### PR TITLE
Update 11ty site url from io to dev

### DIFF
--- a/content/projects/eleventy.md
+++ b/content/projects/eleventy.md
@@ -1,7 +1,7 @@
 ---
 title: Eleventy
 repo: 11ty/eleventy
-homepage: https://11ty.io/
+homepage: https://11ty.dev/
 language:
   - JavaScript
 license:
@@ -24,4 +24,4 @@ twitter: eleven_ty
 
 A simpler static site generator. An alternative to Jekyll. Written in JavaScript. Transforms a directory of templates (of varying types) into HTML.
 
-Works with HTML, Markdown, Liquid, Nunjucks, Handlebars, Mustache, EJS, Haml, Pug, and JavaScript Template Literals.
+Works with HTML, Markdown, JavaScript, Liquid, Nunjucks, Handlebars, Mustache, EJS, Haml, Pug, and JavaScript template literals.


### PR DESCRIPTION
@zachleat [announced](https://www.11ty.dev/news/moving-house/) the main url change from from 11ty dot io to https://11ty.dev/ on December 5, 2019.

I also added JavaScript to the list of "Works with" since ZL distinguishes between JS and JS templates literals in the documentation.