### PR TITLE
#719 Changed stasis language case to TypeScript for better grouping

### DIFF
--- a/content/projects/stasis-generator.md
+++ b/content/projects/stasis-generator.md
@@ -3,7 +3,7 @@ title: Stasis
 repo: Gioni06/stasis-generator
 homepage: https://getstasis.com/
 language:
-  - Typescript
+  - TypeScript
 license:
   - MIT
 templates:


### PR DESCRIPTION
Closes #719 by changing the language of Project 'Stasis' from "Typescript" to "TypeScript" to bring it in uniformity with the other projects in the same language and avoid repetition of Typescript in the language filter.