### PR TITLE
phpoole.md to cecil.md

### DIFF
--- a/content/projects/cecil.md
+++ b/content/projects/cecil.md
@@ -9,7 +9,7 @@ license:
 templates:
   - Twig
 description: Your content driven static site generator.
-startertemplaterepo: Cecilapp/starter-blog
+startertemplaterepo: Cecilapp/the-butler
 twitter: Cecil_Static
 ---
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/phpoole    /cecil


### PR DESCRIPTION
PHPoole was the previous name of Cecil. It's time to fix URL :-)