### PR TITLE
Use "Jamstack"  based on jamstack.org discussions

### DIFF
--- a/content/footer.md
+++ b/content/footer.md
@@ -1,2 +1,2 @@
 StaticGen is hosted and maintained by [Netlify](https://www.netlify.com), the perfect way to deploy
-your JAMstack sites and apps.
+your Jamstack sites and apps.

--- a/content/projects/gatsby.md
+++ b/content/projects/gatsby.md
@@ -35,7 +35,7 @@ Gatsby.js is Internet Scale. Forget complicated deploys with databases and serve
 
 ## Future-proof your website
 
-Don't build a website with last decade's tech. The future of the web is mobile, JavaScript and APIs—the JAMstack. Every website is a web app and every web app is a website. Gatsby.js is the universal JavaScript framework you’ve been waiting for.
+Don't build a website with last decade's tech. The future of the web is mobile, JavaScript and APIs—the Jamstack. Every website is a web app and every web app is a website. Gatsby.js is the universal JavaScript framework you’ve been waiting for.
 
 ## Static Progressive Web Apps
 

--- a/content/projects/gridsome.md
+++ b/content/projects/gridsome.md
@@ -39,7 +39,7 @@ Gridsome automatically optimises your frontend to load and perform blazing fast.
 
 ## Build future ready websites
 
-The future of the web is JavaScript, API's, and Markup - the JAMstack. Gridsome uses the power of blazing-fast static site generator, JavaScript and APIs to create stunning dynamic web experiences.
+The future of the web is JavaScript, API's, and Markup - the Jamstack. Gridsome uses the power of blazing-fast static site generator, JavaScript and APIs to create stunning dynamic web experiences.
 
 ## Ready for global domination
 

--- a/content/projects/platframe.md
+++ b/content/projects/platframe.md
@@ -14,7 +14,7 @@ startertemplaterepo: platframe/platframe
 twitter: platframe
 ---
 
-Whether it's bespoke development, building a JAMstack app, or making it your blog's static site generator, *Platframe* grounds your next project with a resilient foundation.
+Whether it's bespoke development, building a Jamstack app, or making it your blog's static site generator, *Platframe* grounds your next project with a resilient foundation.
 
 ## Setup
 

--- a/site.yaml
+++ b/site.yaml
@@ -2,7 +2,7 @@ url: https://www.staticgen.com
 title: StaticGen
 repo: https://github.com/netlify/staticgen
 titleHome: StaticGen | Top Open Source Static Site Generators
-subtitle: A List of Static Site Generators for JAMstack Sites
+subtitle: A List of Static Site Generators for Jamstack Sites
 description: StaticGen is a leaderboard of the top open source static site generators. Promoting a static approach to building websites.
 socialPreviewImageFilename: staticgen.png
 shareButtons:
@@ -13,7 +13,7 @@ shareTextProjectStart: "Check out "
 shareTextProjectEnd: ", an open source static site generator on the staticgen.com leaderboard."
 copyrightName: Netlify
 navLinks:
-  - { url: https://jamstack.org, text: About JAMstack }
+  - { url: https://jamstack.org, text: About Jamstack }
   - { url: https://headlesscms.org, text: Need a Static CMS? }
 sorts:
   - { field: "stars", label: "Repo stars", reverse: true }

--- a/src/App/Header.js
+++ b/src/App/Header.js
@@ -9,8 +9,8 @@ import NavLink, { NavAnchor } from './NavLink'
 const JamstackConfBanner = ({ className }) => (
   <div className={className}>
     <p>
-      Learn more about the JAMstack at{' '}
-      <a href="https://jamstackconf.com/sf">JAMstack Conf</a> in San Francisco — 16-18 October, 2019
+      Learn more about the Jamstack at{' '}
+      <a href="https://jamstackconf.com/sf">Jamstack Conf</a> in San Francisco — 16-18 October, 2019
     </p>
   </div>
 )


### PR DESCRIPTION
Moving towards more consistent treatment of the word "Jamstack".
This was [discussed in an issue](https://github.com/jamstack/jamstack.org/issues/279) in the jamstack.org site repo, and a decision reached. 
These changes bring staticgen into line with that.

