### PR TITLE
use "Jamstack" as per jamstack.org

### DIFF
--- a/content/projects/gatsby.md
+++ b/content/projects/gatsby.md
@@ -35,7 +35,7 @@ Gatsby.js is Internet Scale. Forget complicated deploys with databases and serve
 
 ## Future-proof your website
 
-Don't build a website with last decade's tech. The future of the web is mobile, JavaScript and APIs—the JAMstack. Every website is a web app and every web app is a website. Gatsby.js is the universal JavaScript framework you’ve been waiting for.
+Don't build a website with last decade's tech. The future of the web is mobile, JavaScript and APIs—the Jamstack. Every website is a web app and every web app is a website. Gatsby.js is the universal JavaScript framework you’ve been waiting for.
 
 ## Static Progressive Web Apps
 

--- a/content/projects/gridsome.md
+++ b/content/projects/gridsome.md
@@ -39,7 +39,7 @@ Gridsome automatically optimises your frontend to load and perform blazing fast.
 
 ## Build future ready websites
 
-The future of the web is JavaScript, API's, and Markup - the JAMstack. Gridsome uses the power of blazing-fast static site generator, JavaScript and APIs to create stunning dynamic web experiences.
+The future of the web is JavaScript, API's, and Markup - the Jamstack. Gridsome uses the power of blazing-fast static site generator, JavaScript and APIs to create stunning dynamic web experiences.
 
 ## Ready for global domination
 

--- a/content/projects/intu-dev.md
+++ b/content/projects/intu-dev.md
@@ -13,8 +13,8 @@ description: INTUITION.DEV is the futuristic open source tool for pro developers
 
 # INTUITION.DEV :
 
-In a future with increasing automation, citizen-developers have become more widespread. Nowadays almost anyone can pull out a form or a web app using low-code tools. Unlike other low-code tools, this one is aimed at professional developers and uses a standard language: Pug. We started first with a static code generator that leverage JAMstack, w/ Pug. And then added a WebAdmin that lets you edit—and then keep adding features. 
-[Medium Article](https://medium.com/@uptimevic/how-software-developers-can-survive-the-coming-tech-crash-796dd8dc5a7e) 
+In a future with increasing automation, citizen-developers have become more widespread. Nowadays almost anyone can pull out a form or a web app using low-code tools. Unlike other low-code tools, this one is aimed at professional developers and uses a standard language: Pug. We started first with a static code generator that leverage Jamstack, w/ Pug. And then added a WebAdmin that lets you edit—and then keep adding features.
+[Medium Article](https://medium.com/@uptimevic/how-software-developers-can-survive-the-coming-tech-crash-796dd8dc5a7e)
 
 ### INTUITION.DEV pro development features:
 

--- a/content/projects/platframe.md
+++ b/content/projects/platframe.md
@@ -14,7 +14,7 @@ startertemplaterepo: platframe/platframe
 twitter: platframe
 ---
 
-Whether it's bespoke development, building a JAMstack app, or making it your blog's static site generator, _Platframe_ grounds your next project with a resilient foundation.
+Whether it's bespoke development, building a Jamstack app, or making it your blog's static site generator, _Platframe_ grounds your next project with a resilient foundation.
 
 ## Setup
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,7 +17,7 @@ module.exports = {
     image: 'https://staticgen.com/images/staticgen.png',
     repo: 'https://github.com/netlify/staticgen',
     homeTitle: 'StaticGen | Top Open Source Static Site Generators',
-    subtitle: 'A List of Static Site Generators for JAMstack Sites',
+    subtitle: 'A List of Static Site Generators for Jamstack Sites',
     description,
     socialPreviewImageFilename: 'staticgen.png',
     shareButtons: ['twitter', 'reddit'],
@@ -26,7 +26,7 @@ module.exports = {
     shareTextProjectEnd: ', an open source static site generator on the staticgen.com leaderboard.',
     footerMarkdown: oneLine`
       StaticGen is hosted and maintained by [Netlify](https://www.netlify.com), the perfect way to
-      deploy your JAMstack sites and apps.
+      deploy your Jamstack sites and apps.
     `,
     copyrightName: 'Netlify',
     promoMarkdown: stripIndent`
@@ -39,7 +39,7 @@ module.exports = {
       here](https://www.netlify.com/docs/deploy_button/).
     `,
     navLinks: [
-      { url: 'https://jamstack.org', text: 'About JAMstack' },
+      { url: 'https://jamstack.org', text: 'About Jamstack' },
       { url: 'https://headlesscms.org', text: 'Need a Static CMS?' },
     ],
     fallbackSortField: 'title',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,7 +26,7 @@ module.exports = {
     shareTextProjectEnd: ', an open source static site generator on the staticgen.com leaderboard.',
     footerMarkdown: oneLine`
       StaticGen is hosted and maintained by [Netlify](https://www.netlify.com), the perfect way to
-      deploy your Jamstack sites and apps.
+      deploy your [Jamstack sites and apps](https://www.netlify.com/jamstack).
     `,
     copyrightName: 'Netlify',
     promoMarkdown: stripIndent`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staticgen",
   "private": true,
-  "description": "StaticGen.com, a list of static site generators for JAMstack sites.",
+  "description": "StaticGen.com, a list of static site generators for Jamstack sites.",
   "version": "3.0.0",
   "author": "@Netlify",
   "dependencies": {

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -62,7 +62,7 @@ const Hero = ({ siteTitle, shareUrl, shareText }) => (
         <LogoText>{siteTitle}</LogoText>
       </LogoLink>
     </HeroHeading>
-    <HeroSubheading>A List of Static Site Generators for JAMstack Sites</HeroSubheading>
+    <HeroSubheading>A List of Static Site Generators for Jamstack Sites</HeroSubheading>
 
     <ShareButtonGroup>
       {['twitter', 'reddit'].map(type => (

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -79,9 +79,9 @@ const Layout = ({ projectTitle, projectUrl, projectId, children }) => {
   return (
     <>
       <Global styles={globalStyles} />
-   
+
       <Banner>
-        Share your JAMstack technology decisions and experiences. <a href="https://www.surveymonkey.com/r/DH9KZZT" target="_blank" rel="noopener noreferrer">Take&nbsp;the&nbsp;survey&nbsp;by&nbsp;April&nbsp;19</a>
+        Share your Jamstack technology decisions and experiences. <a href="https://www.surveymonkey.com/r/DH9KZZT" target="_blank" rel="noopener noreferrer">Take&nbsp;the&nbsp;survey&nbsp;by&nbsp;April&nbsp;19</a>
       </Banner>
 
       <Hero siteTitle={data.site.siteMetadata.title} shareText={shareText} shareUrl={shareUrl} />
@@ -89,7 +89,7 @@ const Layout = ({ projectTitle, projectUrl, projectId, children }) => {
         <NavLink to="/about">About</NavLink>
         <NavLink to="/contribute">Contribute</NavLink>
         <NavAnchor href="https://jamstack.org" target="_blank" rel="noopener noreferrer">
-          About JAMstack
+          About Jamstack
         </NavAnchor>
         <NavAnchor href="https://headlesscms.org" target="_blank" rel="noopener noreferrer">
           Need a Static CMS?


### PR DESCRIPTION
Moving towards more consistent treatment of the word "Jamstack".
This was [discussed in an issue](https://github.com/jamstack/jamstack.org/issues/279) in the jamstack.org site repo, and a decision reached.

These changes bring staticgen into line with that.