### PR TITLE
Updated Stog's homepage

### DIFF
--- a/content/projects/stog.md
+++ b/content/projects/stog.md
@@ -1,7 +1,7 @@
 ---
 title: Stog
 repo: zoggy/stog
-homepage: http://zoggy.github.io/stog/
+homepage: https://www.good-eris.net/stog/
 language:
   - OCaml
 license:


### PR DESCRIPTION
While exploring SSG made with OCaml, I realized that Stog has changed its homepage from http://zoggy.github.io/stog/ to https://www.good-eris.net/stog/. This PR fixes it.