### PR TITLE
Add Static Markdown

### DIFF
--- a/content/projects/static-markdown.md
+++ b/content/projects/static-markdown.md
@@ -1,0 +1,20 @@
+---
+title: Static Markdown
+repo: tripplyons/static-markdown
+homepage: https://github.com/tripplyons/static-markdown/
+language:
+  - JavaScript
+license:
+  - MIT
+templates:
+  - Handlebars
+description: Generate static sites using markdown or HTML
+---
+
+Static Markdown is a tool for converting Markdown and HTML articles into full websites.
+
+Packaged as an NPM module, it is easy to install, run, and integrate into a build process.
+
+You can start with a theme from the the repository, and change it as you wish.
+
+Don't repeat yourself, use templates to fill in site-wide variables and article specific ones.


### PR DESCRIPTION
I would like to add a static site generator that I have been working on to your list.

It is called Static Markdown, and you can find it at [tripplyons/static-markdown](https://github.com/tripplyons/static-markdown/).