### PR TITLE
change language for Cogear.JS to JavaScript

### DIFF
--- a/content/projects/cogear.js.md
+++ b/content/projects/cogear.js.md
@@ -3,7 +3,7 @@ title: Cogear.JS
 repo: codemotion/cogear.js
 homepage: https://cogearjs.org
 language:
-  - Node.JS
+  - JavaScript
 license:
   - MIT
 templates:


### PR DESCRIPTION
Cogear.JS is the sole listing for the Node.JS language on the site.
All other projects that also use nodeJS are listed under JavaScript.

Signed-off-by: shine <4771718+shinenelson@users.noreply.github.com>