### PR TITLE
Fix language capitalization for Codedoc

### DIFF
--- a/content/projects/codedoc.md
+++ b/content/projects/codedoc.md
@@ -3,7 +3,7 @@ title: Codedoc
 repo: CONNECT-platform/codedoc
 homepage: https://codedoc.cc
 language:
-  - Typescript
+  - TypeScript
 license:
   - MIT
 templates:


### PR DESCRIPTION
Change 'Typescript' to 'TypeScript'