### PR TITLE
fix repo, Twitter links;desc for WP2Static

### DIFF
--- a/content/projects/wp2static.md
+++ b/content/projects/wp2static.md
@@ -1,17 +1,13 @@
 ---
 title: WP2Static
-repo: leonstafford/wp2static
+repo: wp2static/wp2static
 homepage: https://wp2static.com
 language:
   - PHP
 license:
   - Unlicense
 description: Leverage WordPress as a great CMS, but benefit from the speed, security and portability that a static website provides
-twitter: wp2static
 ---
 
-WordPress plugin to publish a static copy of your site to GitHub Pages, S3, Netlify or anywhere else you can pipe into your CI/CD workflow.
+WordPress plugin to publish a static copy of your site to S3, Cloudflare, GitHub Pages, Netlify or anywhere else you can pipe into your CI/CD workflow.
 
-Formerly, "WP Static Site Generator"
-
-For all the reasons why to use it and the benefits of going static, visit [https://wp2static.com](https://wp2static.com). For documentation, there's a [site for that](https://docs.wp2static.com), too.


### PR DESCRIPTION
 - GH repo was moved to org 
 - Twitter handle no longer owned me/WP2Static, is unofficial 