### PR TITLE
Fix capitalization of JavaScript in elderjs.md

### DIFF
--- a/content/projects/elderjs.md
+++ b/content/projects/elderjs.md
@@ -3,7 +3,7 @@ title: Elder.js
 repo: elderjs/elderjs
 homepage: https://elderguide.com/tech/elderjs/
 language:
-  - Javascript
+  - JavaScript
 license:
   - MIT License
 templates:


### PR DESCRIPTION
Otherwise it shows up in a separate list entry in the Languages dropdown menu, compared to the other JavaScript projects.