### PR TITLE
Add Publish

### DIFF
--- a/content/projects/publish.md
+++ b/content/projects/publish.md
@@ -1,0 +1,17 @@
+---
+title: Publish
+repo: JohnSundell/Publish
+homepage: https://github.com/JohnSundell/Publish
+language:
+  - Swift
+license:
+  - MIT
+templates:
+  - Markdown
+description: A static site generator built specifically for Swift developers.
+twitter: swiftbysundell
+---
+
+**Publish** is a static site generator built specifically for Swift developers. It enables entire websites to be built using Swift, and supports themes, plugins and tons of other powerful customization options.
+
+Follow [the official guide](https://github.com/JohnSundell/Publish) to get started.


### PR DESCRIPTION
Publish (https://github.com/JohnSundell/Publish) is a static website generator meant for Swift developers.