### PR TITLE
Updating elder.js to make "Javascript", "JavaScript"

### DIFF
--- a/content/projects/elderjs.md
+++ b/content/projects/elderjs.md
@@ -3,7 +3,7 @@ title: Elder.js
 repo: elderjs/elderjs
 homepage: https://elderguide.com/tech/elderjs/
 language:
-  - Javascript
+  - JavaScript
 license:
   - MIT License
 templates:


### PR DESCRIPTION
Seems that the filtering functionality on the website is case sensitive, so Javascript (used here) and JavaScript appear as two distinct options. Updating Elder to conform with the rest of the site