### PR TITLE
update Next Documentation

### DIFF
--- a/content/projects/next.md
+++ b/content/projects/next.md
@@ -38,7 +38,7 @@ Add a build script
 
 ## Run
 
-After that, the file-system is the main API. Every `.js` file becomes a route that gets automatically processed and rendered.
+After that, the file-system is the main API. Every `.js` file within the automatically created `pages` directory becomes a route that gets automatically processed and rendered.
 
 ## Example
 


### PR DESCRIPTION
This PR updates the NextJS documentation. Only `.js` files within the pages directory are mapped to routes. 