### PR TITLE
Add redirects to jamstack.org

### DIFF
--- a/content/projects/saber.md
+++ b/content/projects/saber.md
@@ -1,6 +1,6 @@
 ---
 title: Saber
-repo: egoist/saber
+repo: saberland/saber
 homepage: https://saber.land/
 language:
   - JavaScript

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,4 @@
-/ https://jamstack.org/ 301!
-/about https://jamstack.org/generators/ 301!
-/contribute https://jamstack.org/generators/ 301!
+/ https://next-design-iteration--jamstack-site.netlify.app/ 301!
+/about https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
+/contribute https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
 /* https://next-design-iteration--jamstack-site.netlify.app/generators/:splat 301!

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,4 @@
 / https://next-design-iteration--jamstack-site.netlify.app/ 301!
 /about https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
 /contribute https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
-/* https://next-design-iteration--jamstack-site.netlify.app/generators/:splat 301!
+/* https://next-design-iteration--jamstack-site.netlify.app/generators/:splat 301!/

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,4 @@
-/phpoole    /cecil
+/ https://jamstack.org/ 301!
+/about https://jamstack.org/generators/ 301!
+/contribute https://jamstack.org/generators/ 301!
+/* https://next-design-iteration--jamstack-site.netlify.app/generators/:splat 301!

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,4 @@
 / https://next-design-iteration--jamstack-site.netlify.app/ 301!
 /about https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
 /contribute https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
-/* https://next-design-iteration--jamstack-site.netlify.app/generators/:splat 301!/
+/* https://next-design-iteration--jamstack-site.netlify.app/generators/:splat 301!

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,4 @@
-/ https://next-design-iteration--jamstack-site.netlify.app/ 301!
-/about https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
-/contribute https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
-/* https://next-design-iteration--jamstack-site.netlify.app/generators/:splat 301!
+/ https://www.jamstack.org/ 301!
+/about https://www.jamstack.org/generators/ 301!
+/contribute https://www.jamstack.org/generators/ 301!
+/* https://www.jamstack.org/generators/:splat 301!


### PR DESCRIPTION
⚠️ I currently redirects to the deploy preview just to make sure that it works, will edit once it's ready ⚠️

Following [Netlify's Rule processing order](https://docs.netlify.com/routing/redirects/#rule-processing-order) - If you try to access else than:
-  `/`
- `/about`
- `/contribute`

it will assume that it's a generators and redirect to `/generators/*`

### Test plan

Here's some link to test and make sure the redirect work

https://deploy-preview-902--staticgen.netlify.app/
https://deploy-preview-902--staticgen.netlify.app/about
https://deploy-preview-902--staticgen.netlify.app/contribute
https://deploy-preview-902--staticgen.netlify.app/next
https://deploy-preview-902--staticgen.netlify.app/eleventy